### PR TITLE
🔀 :: (#9) publishing for signup page

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/presentation/src/main/java/com/msg/presentation/view/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/signup/SignUpScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun SignUpScreen() {
-    val url = "https://www.dotori-gsm.com/signup"
-
     AndroidView(factory = {
         WebView(it).apply {
             layoutParams = ViewGroup.LayoutParams(
@@ -34,7 +32,7 @@ fun SignUpScreen() {
                     handler!!.proceed()
                 }
             }
-            loadUrl(url)
+            loadUrl("https://www.dotori-gsm.com/signup")
         }
     })
 }

--- a/presentation/src/main/java/com/msg/presentation/view/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/signup/SignUpScreen.kt
@@ -1,0 +1,39 @@
+package com.msg.presentation.view.signup
+
+import android.annotation.SuppressLint
+import android.net.http.SslError
+import android.view.ViewGroup
+import android.webkit.SslErrorHandler
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun SignUpScreen() {
+    val url = "https://www.dotori-gsm.com/signup"
+
+    AndroidView(factory = {
+        WebView(it).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            webViewClient = object : WebViewClient() {
+                @SuppressLint("WebViewClientOnReceivedSslError")
+                override fun onReceivedSslError(
+                    view: WebView?,
+                    handler: SslErrorHandler?,
+                    error: SslError?
+                ) {
+                    super.onReceivedSslError(view, handler, error)
+                    handler!!.proceed()
+                }
+            }
+            loadUrl(url)
+        }
+    })
+}

--- a/presentation/src/main/java/com/msg/presentation/view/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/signup/SignUpScreen.kt
@@ -7,6 +7,7 @@ import android.webkit.SslErrorHandler
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
 
 @SuppressLint("SetJavaScriptEnabled")
@@ -36,4 +37,10 @@ fun SignUpScreen() {
             loadUrl(url)
         }
     })
+}
+
+@Preview
+@Composable
+fun SignUpScreenPreview() {
+    SignUpScreen()
 }


### PR DESCRIPTION
## 📌 개요
- 회원가입 페이지 퍼블리싱

## ✨ 구현 내용
- uses-permission를 사용하여 INTETNET 허락
- SignUpScreen 구현

## 📸  디자인
![image](https://github.com/Team-Ampersand/Dotori-Android/assets/84944098/2b341eca-0d42-4f53-8349-020800887b45)
![image](https://github.com/Team-Ampersand/Dotori-Android/assets/84944098/3aba6aaf-6ac5-4fe4-a961-10ad6be5eb27)
![image](https://github.com/Team-Ampersand/Dotori-Android/assets/84944098/630bcd25-c754-4e42-890d-25b757b63eeb)

## 📸 구현 화면 (선택)
<img width="396" alt="image" src="https://github.com/Team-Ampersand/Dotori-Android/assets/84944098/1a1dc350-97ed-45fe-be16-04ce1998a4d7">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- url를 local.properties로 숨기는게 좋을까요?
- 회원가입 2번째 단계까지 제 핸드폰으로 테스트 완료했습니다