### PR TITLE
🔀 :: (#32) massage chair publishing

### DIFF
--- a/presentation/src/main/java/com/msg/presentation/view/component/DotoriTopBar.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/component/DotoriTopBar.kt
@@ -1,0 +1,29 @@
+package com.msg.presentation.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.dotori.dotori_components.components.toggle.DotoriThemeSwitchButton
+import com.dotori.dotori_components.theme.DotoriText
+import com.dotori.dotori_components.theme.DotoriTheme
+
+@Composable
+fun DotoriTopBar(onSwitchClick: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(DotoriTheme.colors.cardBackground)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        DotoriText()
+        DotoriThemeSwitchButton(onSwitchClick = onSwitchClick)
+    }
+}

--- a/presentation/src/main/java/com/msg/presentation/view/massage_chair/MassageChairScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/massage_chair/MassageChairScreen.kt
@@ -1,0 +1,78 @@
+package com.msg.presentation.view.massage_chair
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dotori.dotori_components.components.card.DotoriStudentCard
+import com.dotori.dotori_components.components.utils.Types
+import com.dotori.dotori_components.theme.DotoriTheme
+import com.msg.presentation.view.massage_chair.component.DotoriTopBar
+import com.msg.presentation.view.massage_chair.component.EmptyMassageChairScreen
+import com.msg.presentation.view.massage_chair.component.MassageChairTopBar
+
+@Composable
+fun MassageChairScreen() {
+    val list = listOf(1,2,3,4,5)
+
+    if (list.isEmpty()) MassageChairIsEmptyContent()
+    else MassageChairStudentListContent(list)
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+fun MassageChairStudentListContent(list: List<Int>) {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item { DotoriTopBar(onSwitchClick = {}) }
+
+        item {
+            Divider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = 1.dp,
+                color = DotoriTheme.colors.background
+            )
+        }
+
+        stickyHeader { MassageChairTopBar() }
+
+        items(list) { position ->
+            DotoriStudentCard(
+                name = "임가람",
+                gender = "MAN",
+                role = "ROLE_MEMBER",
+                studentNumber = "3412",
+                position = position,
+                mode = Types.CardType.MASSAGE_CHAIR,
+                isLast = list.lastIndex + 1 == position,
+                onCheckBoxChange = {}
+            )
+        }
+    }
+}
+
+@Composable
+fun MassageChairIsEmptyContent() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        DotoriTopBar(onSwitchClick = {})
+        Divider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = DotoriTheme.colors.background
+        )
+        MassageChairTopBar()
+        EmptyMassageChairScreen()
+    }
+}
+
+@Preview
+@Composable
+private fun MassageChairScreenPreview() {
+    MassageChairScreen()
+}

--- a/presentation/src/main/java/com/msg/presentation/view/massage_chair/MassageChairScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/massage_chair/MassageChairScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.dotori.dotori_components.components.card.DotoriStudentCard
 import com.dotori.dotori_components.components.utils.Types
 import com.dotori.dotori_components.theme.DotoriTheme
-import com.msg.presentation.view.massage_chair.component.DotoriTopBar
+import com.msg.presentation.view.component.DotoriTopBar
 import com.msg.presentation.view.massage_chair.component.EmptyMassageChairScreen
 import com.msg.presentation.view.massage_chair.component.MassageChairTopBar
 

--- a/presentation/src/main/java/com/msg/presentation/view/massage_chair/component/EmptyMassageChairScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/massage_chair/component/EmptyMassageChairScreen.kt
@@ -1,0 +1,51 @@
+package com.msg.presentation.view.massage_chair.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.dotori.dotori_components.theme.DotoriTheme
+import com.msg.presentation.R
+
+@Composable
+fun EmptyMassageChairScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(DotoriTheme.colors.background),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        val image = painterResource(
+            id = if (DotoriTheme.isSystemIsDarkTheme())
+                R.drawable.ic_empty_massage_chair_icon_dark
+            else R.drawable.ic_empty_massage_chair_icon_light
+        )
+
+        Image(
+            painter = image,
+            contentDescription = "empty massage chair student"
+        )
+
+        Text(
+            modifier = Modifier.padding(horizontal = 8.dp),
+            text = "안마의자를 신청한 인원이 없습니다..",
+            style = DotoriTheme.typography.subTitle2,
+            color = DotoriTheme.colors.neutral10
+        )
+
+        Text(
+            text = "홈에서 안마의자 신청을 해보세요!",
+            style = DotoriTheme.typography.caption,
+            color = DotoriTheme.colors.neutral20
+        )
+    }
+}

--- a/presentation/src/main/java/com/msg/presentation/view/massage_chair/component/MassageChairTopBar.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/massage_chair/component/MassageChairTopBar.kt
@@ -10,24 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.dotori.dotori_components.components.toggle.DotoriThemeSwitchButton
-import com.dotori.dotori_components.theme.DotoriText
 import com.dotori.dotori_components.theme.DotoriTheme
-
-@Composable
-fun DotoriTopBar(onSwitchClick: (Boolean) -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(DotoriTheme.colors.cardBackground)
-            .padding(horizontal = 20.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        DotoriText()
-        DotoriThemeSwitchButton(onSwitchClick = onSwitchClick)
-    }
-}
 
 @Composable
 fun MassageChairTopBar() {

--- a/presentation/src/main/java/com/msg/presentation/view/massage_chair/component/TopBar.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/massage_chair/component/TopBar.kt
@@ -1,0 +1,48 @@
+package com.msg.presentation.view.massage_chair.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.dotori.dotori_components.components.toggle.DotoriThemeSwitchButton
+import com.dotori.dotori_components.theme.DotoriText
+import com.dotori.dotori_components.theme.DotoriTheme
+
+@Composable
+fun DotoriTopBar(onSwitchClick: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(DotoriTheme.colors.cardBackground)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        DotoriText()
+        DotoriThemeSwitchButton(onSwitchClick = onSwitchClick)
+    }
+}
+
+@Composable
+fun MassageChairTopBar() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(DotoriTheme.colors.cardBackground)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "안마의자",
+            style = DotoriTheme.typography.subTitle1,
+            color = DotoriTheme.colors.neutral10
+        )
+    }
+}

--- a/presentation/src/main/java/com/msg/presentation/view/self_study/SelfStudyScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/self_study/SelfStudyScreen.kt
@@ -22,8 +22,8 @@ import com.dotori.dotori_components.components.bottomsheet.DotoriBottomSheetDial
 import com.dotori.dotori_components.components.card.DotoriStudentCard
 import com.dotori.dotori_components.components.utils.Types
 import com.dotori.dotori_components.theme.DotoriTheme
+import com.msg.presentation.view.component.DotoriTopBar
 import com.msg.presentation.view.self_study.component.BottomSheetContent
-import com.msg.presentation.view.self_study.component.DotoriTopBar
 import com.msg.presentation.view.self_study.component.EmptySelfStudyScreen
 import com.msg.presentation.view.self_study.component.SelfStudyTopBar
 import kotlinx.coroutines.launch

--- a/presentation/src/main/java/com/msg/presentation/view/self_study/SelfStudyScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/self_study/SelfStudyScreen.kt
@@ -3,8 +3,10 @@ package com.msg.presentation.view.self_study
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -15,9 +17,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.dotori.dotori_components.components.bottomsheet.DotoriBottomSheetDialog
 import com.dotori.dotori_components.components.card.DotoriStudentCard
 import com.dotori.dotori_components.components.utils.Types
+import com.dotori.dotori_components.theme.DotoriTheme
 import com.msg.presentation.view.self_study.component.BottomSheetContent
 import com.msg.presentation.view.self_study.component.DotoriTopBar
 import com.msg.presentation.view.self_study.component.EmptySelfStudyScreen
@@ -63,6 +67,12 @@ fun SelfStudyIsEmptyContent(onFilterIconClick: () -> Unit, ) {
     Column(modifier = Modifier.fillMaxSize()) {
         DotoriTopBar(onSwitchClick = { /*TODO*/ })
 
+        Divider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = DotoriTheme.colors.background
+        )
+
         SelfStudyTopBar { onFilterIconClick() }
 
         EmptySelfStudyScreen()
@@ -81,6 +91,14 @@ fun SelfStudyStudentListContent(
         modifier = Modifier.fillMaxSize(),
     ) {
         item { DotoriTopBar(onSwitchClick = { /*TODO*/ }) }
+
+        item {
+            Divider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = 1.dp,
+                color = DotoriTheme.colors.background
+            )
+        }
 
         stickyHeader { SelfStudyTopBar { onFilterIconClick() } }
 

--- a/presentation/src/main/java/com/msg/presentation/view/self_study/component/SelfStudyTopBar.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/self_study/component/SelfStudyTopBar.kt
@@ -11,25 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.dotori.dotori_components.components.toggle.DotoriThemeSwitchButton
-import com.dotori.dotori_components.theme.DotoriText
 import com.dotori.dotori_components.theme.DotoriTheme
 import com.dotori.dotori_components.theme.FilterIcon
-
-@Composable
-fun DotoriTopBar(onSwitchClick: (Boolean) -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(DotoriTheme.colors.cardBackground)
-            .padding(horizontal = 20.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        DotoriText()
-        DotoriThemeSwitchButton(onSwitchClick = onSwitchClick)
-    }
-}
 
 @Composable
 fun SelfStudyTopBar(onFilterIconClick: () -> Unit) {

--- a/presentation/src/main/res/drawable/ic_empty_massage_chair_icon_dark.xml
+++ b/presentation/src/main/res/drawable/ic_empty_massage_chair_icon_dark.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="65dp"
+    android:height="113dp"
+    android:viewportWidth="65"
+    android:viewportHeight="113">
+  <path
+      android:pathData="M61.5,73.09C61.5,86.86 46.77,91.84 36,91.84C25.23,91.84 25.5,91.36 25.5,80.59C25.5,69.82 34.23,63.34 45,63.34C55.77,63.34 61.5,65.32 61.5,73.09Z"
+      android:strokeWidth="5.99997"
+      android:fillColor="#00000000"
+      android:strokeColor="#CDCDD5"/>
+  <path
+      android:pathData="M3,64.09C3,59.12 7.03,55.09 12,55.09H39C43.97,55.09 48,59.12 48,64.09V100.09C48,105.06 43.97,109.09 39,109.09H12C7.03,109.09 3,105.06 3,100.09V64.09Z"
+      android:strokeWidth="5.99997"
+      android:fillColor="#1F1E2B"
+      android:strokeColor="#CDCDD5"/>
+  <path
+      android:pathData="M27.85,3.91C24,4.75 5.51,10.17 39.78,18.63C57.69,23.05 -12.75,23.88 14.44,30.41C20.55,31.87 43.87,35.13 27.85,43.66"
+      android:strokeWidth="5.99997"
+      android:fillColor="#00000000"
+      android:strokeColor="#818198"
+      android:strokeLineCap="round"/>
+</vector>

--- a/presentation/src/main/res/drawable/ic_empty_massage_chair_icon_light.xml
+++ b/presentation/src/main/res/drawable/ic_empty_massage_chair_icon_light.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="65dp"
+    android:height="113dp"
+    android:viewportWidth="65"
+    android:viewportHeight="113">
+  <path
+      android:pathData="M61.5,73.09C61.5,86.86 46.77,91.84 36,91.84C25.23,91.84 25.5,91.36 25.5,80.59C25.5,69.82 34.23,63.34 45,63.34C55.77,63.34 61.5,65.32 61.5,73.09Z"
+      android:strokeWidth="5.99997"
+      android:fillColor="#00000000"
+      android:strokeColor="#656B80"/>
+  <path
+      android:pathData="M3,64.09C3,59.12 7.03,55.09 12,55.09H39C43.97,55.09 48,59.12 48,64.09V100.09C48,105.06 43.97,109.09 39,109.09H12C7.03,109.09 3,105.06 3,100.09V64.09Z"
+      android:strokeWidth="5.99997"
+      android:fillColor="#F7F7F9"
+      android:strokeColor="#656B80"/>
+  <path
+      android:pathData="M27.85,3.91C24,4.75 5.51,10.17 39.78,18.63C57.69,23.05 -12.75,23.88 14.44,30.41C20.55,31.87 43.87,35.13 27.85,43.66"
+      android:strokeWidth="5.99997"
+      android:fillColor="#00000000"
+      android:strokeColor="#BBBBCC"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## 📌 개요
- 안마의자 페이지 퍼블리싱

## ✨ 구현 내용
- 빈 안마의자 페이지, 안마의자 페이지 퍼블리싱

## 📸 구현 화면 (선택)
![image](https://github.com/Team-Ampersand/Dotori-Android/assets/84944117/8dcd5dbe-bc84-4c27-886c-1b2cc5d449a8)
![image](https://github.com/Team-Ampersand/Dotori-Android/assets/84944117/e908543e-45f8-4add-9b19-b67d9f6e9e3a)

## 📸 구현 영상 (선택)
<!-- 영상이 필요하다면 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 자습 신청 페이지의 divier를 이 pr에 함께 넣었습니다. 참고해 주세요
