### PR TITLE
🔀 :: (#66) self study view model

### DIFF
--- a/data/src/main/java/com/msg/data/remote/datasource/self_study/SelfStudyDataSource.kt
+++ b/data/src/main/java/com/msg/data/remote/datasource/self_study/SelfStudyDataSource.kt
@@ -2,6 +2,7 @@ package com.msg.data.remote.datasource.self_study
 
 import com.msg.data.remote.dto.self_study.SelfStudyInfoResponse
 import com.msg.data.remote.dto.self_study.SelfStudyListResponse
+import okhttp3.ResponseBody
 
 interface SelfStudyDataSource {
     suspend fun getSelfStudyInfo(
@@ -30,9 +31,9 @@ interface SelfStudyDataSource {
         userId: Long
     )
 
-    suspend fun selfStudy(role: String)
+    suspend fun selfStudy(role: String): ResponseBody
 
-    suspend fun cancelSelfStudy(role: String)
+    suspend fun cancelSelfStudy(role: String): ResponseBody
 
     suspend fun changeSelfStudyLimit(
         role: String,

--- a/data/src/main/java/com/msg/data/remote/datasource/self_study/SelfStudyDataSourceImpl.kt
+++ b/data/src/main/java/com/msg/data/remote/datasource/self_study/SelfStudyDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.msg.data.remote.dto.self_study.SelfStudyInfoResponse
 import com.msg.data.remote.dto.self_study.SelfStudyListResponse
 import com.msg.data.remote.network.SelfStudyApi
 import com.msg.data.remote.util.safeApiCall
+import okhttp3.ResponseBody
 import javax.inject.Inject
 
 class SelfStudyDataSourceImpl @Inject constructor(
@@ -47,11 +48,11 @@ class SelfStudyDataSourceImpl @Inject constructor(
         )
     }
 
-    override suspend fun selfStudy(role: String) = safeApiCall {
+    override suspend fun selfStudy(role: String): ResponseBody = safeApiCall {
         selfStudyApi.selfStudy(role = role)
     }
 
-    override suspend fun cancelSelfStudy(role: String) = safeApiCall {
+    override suspend fun cancelSelfStudy(role: String): ResponseBody = safeApiCall {
         selfStudyApi.cancelSelfStudy(role = role)
     }
 

--- a/data/src/main/java/com/msg/data/remote/network/SelfStudyApi.kt
+++ b/data/src/main/java/com/msg/data/remote/network/SelfStudyApi.kt
@@ -2,6 +2,7 @@ package com.msg.data.remote.network
 
 import com.msg.data.remote.dto.self_study.SelfStudyInfoResponse
 import com.msg.data.remote.dto.self_study.SelfStudyListResponse
+import okhttp3.ResponseBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -46,12 +47,12 @@ interface SelfStudyApi {
     @POST("/{role}/self-study")
     suspend fun selfStudy(
         @Path("role") role: String
-    )
+    ): ResponseBody
 
     @DELETE("/{role}/self-study")
     suspend fun cancelSelfStudy(
         @Path("role") role: String
-    )
+    ): ResponseBody
 
     @PATCH("/{role}/self-study/limit")
     suspend fun changeSelfStudyLimit(

--- a/data/src/main/java/com/msg/data/repository/SelfStudyRepositoryImpl.kt
+++ b/data/src/main/java/com/msg/data/repository/SelfStudyRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.msg.data.remote.dto.self_study.asSelfStudyListResponseModel
 import com.msg.domain.model.self_study.SelfStudyInfoResponseModel
 import com.msg.domain.model.self_study.SelfStudyListResponseModel
 import com.msg.domain.repository.SelfStudyRepository
+import okhttp3.ResponseBody
 import javax.inject.Inject
 
 class SelfStudyRepositoryImpl @Inject constructor(
@@ -43,10 +44,10 @@ class SelfStudyRepositoryImpl @Inject constructor(
             userId = userId
         )
 
-    override suspend fun selfStudy(role: String) =
+    override suspend fun selfStudy(role: String): ResponseBody =
         selfStudyDataSource.selfStudy(role)
 
-    override suspend fun cancelSelfStudy(role: String) =
+    override suspend fun cancelSelfStudy(role: String): ResponseBody =
         selfStudyDataSource.cancelSelfStudy(role)
 
     override suspend fun changeSelfStudyLimit(role: String, limit: Int) =

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -32,6 +32,9 @@ android {
 }
 
 dependencies {
+    // okhttp
+    implementation(Dependency.Libraries.OKHTTP)
+
     implementation(Dependency.Androidx.CORE_KTX)
     implementation(Dependency.Androidx.APP_COMPAT)
 

--- a/domain/src/main/java/com/msg/domain/repository/SelfStudyRepository.kt
+++ b/domain/src/main/java/com/msg/domain/repository/SelfStudyRepository.kt
@@ -2,6 +2,7 @@ package com.msg.domain.repository
 
 import com.msg.domain.model.self_study.SelfStudyInfoResponseModel
 import com.msg.domain.model.self_study.SelfStudyListResponseModel
+import okhttp3.ResponseBody
 
 interface SelfStudyRepository {
     suspend fun getSelfStudyInfo(
@@ -32,11 +33,11 @@ interface SelfStudyRepository {
 
     suspend fun selfStudy(
         role: String
-    )
+    ): ResponseBody
 
     suspend fun cancelSelfStudy(
         role: String
-    )
+    ): ResponseBody
 
     suspend fun changeSelfStudyLimit(
         role: String,

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -40,6 +40,9 @@ android {
 dependencies {
     implementation(project(":domain"))
 
+    // okhttp
+    implementation(Dependency.Libraries.OKHTTP)
+
     implementation(Dependency.Androidx.CORE_KTX)
     implementation(Dependency.Androidx.APP_COMPAT)
     implementation(Dependency.Androidx.VIEWMODEl)

--- a/presentation/src/main/java/com/msg/presentation/viewmodel/SelfStudyViewModel.kt
+++ b/presentation/src/main/java/com/msg/presentation/viewmodel/SelfStudyViewModel.kt
@@ -1,0 +1,205 @@
+package com.msg.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.msg.domain.model.self_study.SelfStudyInfoResponseModel
+import com.msg.domain.model.self_study.SelfStudyListResponseModel
+import com.msg.domain.usecase.self_study.BanCancelSelfStudyUseCase
+import com.msg.domain.usecase.self_study.BanSelfStudyUseCase
+import com.msg.domain.usecase.self_study.CancelSelfStudyUseCase
+import com.msg.domain.usecase.self_study.ChangeSelfStudyLimitUseCase
+import com.msg.domain.usecase.self_study.CheckSelfStudyUseCase
+import com.msg.domain.usecase.self_study.GetSelfStudyInfoUseCase
+import com.msg.domain.usecase.self_study.GetSelfStudyListUseCase
+import com.msg.domain.usecase.self_study.SearchSelfStudyStudentUseCase
+import com.msg.domain.usecase.self_study.SelfStudyUseCase
+import com.msg.presentation.exception.exceptionHandling
+import com.msg.presentation.viewmodel.util.Event
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import javax.inject.Inject
+
+@HiltViewModel
+class SelfStudyViewModel @Inject constructor(
+    private val selfStudyInfoUseCase: GetSelfStudyInfoUseCase,
+    private val selfStudyListUseCase: GetSelfStudyListUseCase,
+    private val searchSelfStudyStudentUseCase: SearchSelfStudyStudentUseCase,
+    private val banSelfStudyUseCase: BanSelfStudyUseCase,
+    private val banCancelSelfStudyUseCase: BanCancelSelfStudyUseCase,
+    private val selfStudyUseCase: SelfStudyUseCase,
+    private val cancelSelfStudyUseCase: CancelSelfStudyUseCase,
+    private val changeSelfStudyLimitUseCase: ChangeSelfStudyLimitUseCase,
+    private val checkSelfStudyUseCase: CheckSelfStudyUseCase
+): ViewModel() {
+    private val _selfStudyInfoState = MutableStateFlow<Event<SelfStudyInfoResponseModel>>(Event.Loading)
+    val selfStudyInfoState = _selfStudyInfoState.asStateFlow()
+
+    private val _selfStudyListState = MutableStateFlow<Event<List<SelfStudyListResponseModel>>>(Event.Loading)
+    val selfStudyListState = _selfStudyListState.asStateFlow()
+
+    private val _searchSelfStudyStudentState = MutableStateFlow<Event<List<SelfStudyListResponseModel>>>(Event.Loading)
+    val searchSelfStudyStudentState = _searchSelfStudyStudentState.asStateFlow()
+
+    private val _banSelfStudyState = MutableStateFlow<Event<Nothing>>(Event.Loading)
+    val banSelfStudyState = _banSelfStudyState.asStateFlow()
+
+    private val _banCancelSelfStudyState = MutableStateFlow<Event<Nothing>>(Event.Loading)
+    val banCancelSelfStudyState = _banCancelSelfStudyState.asStateFlow()
+
+    private val _selfStudyState = MutableStateFlow<Event<Nothing>>(Event.Loading)
+    val selfStudyState = _selfStudyState.asStateFlow()
+
+    private val _cancelSelfStudyState = MutableStateFlow<Event<Nothing>>(Event.Loading)
+    val cancelSelfStudyState = _cancelSelfStudyState.asStateFlow()
+
+    private val _changeSelfStudyLimitState = MutableStateFlow<Event<Nothing>>(Event.Loading)
+    val changeSelfStudyLimitState = _changeSelfStudyLimitState.asStateFlow()
+
+    private val _checkSelfStudyState = MutableStateFlow<Event<Nothing>>(Event.Loading)
+    val checkSelfStudyState = _checkSelfStudyState.asStateFlow()
+
+    fun getSelfStudyInfo(role: String) = viewModelScope.launch {
+        selfStudyInfoUseCase(role)
+            .onSuccess {
+                _selfStudyInfoState.value = Event.Success(it)
+            }.onFailure {
+                it.exceptionHandling(
+                    badRequestAction = { _selfStudyInfoState.value = Event.BadRequest }
+                )
+            }
+    }
+
+    fun getSelfStudyList(role: String) = viewModelScope.launch {
+        selfStudyListUseCase(role)
+            .onSuccess {
+                _selfStudyListState.value = Event.Success(it)
+            }.onFailure {
+                it.exceptionHandling(
+                    badRequestAction = { _selfStudyListState.value = Event.BadRequest }
+                )
+            }
+    }
+
+    fun searchSelfStudyStudent(
+        role: String,
+        name: String?,
+        gender: String?,
+        classNum: String?,
+        grade: Int?
+    ) = viewModelScope.launch {
+        searchSelfStudyStudentUseCase(
+            role = role,
+            name = name,
+            gender = gender,
+            classNum = classNum,
+            grade = grade
+        ).onSuccess {
+            _searchSelfStudyStudentState.value = Event.Success(it)
+        }.onFailure {
+
+        }
+    }
+
+    fun banSelfStudy(
+        role: String,
+        userId: Long
+    ) = viewModelScope.launch {
+        banSelfStudyUseCase(
+            role = role,
+            userId = userId
+        ).onSuccess {
+            _banSelfStudyState.value = Event.Success()
+        }.onFailure {
+            it.exceptionHandling(
+                notFoundAction = { _banSelfStudyState.value = Event.NotFound }
+            )
+        }
+    }
+
+    fun banCancelSelfStudy(
+        role: String,
+        userId: Long
+    ) = viewModelScope.launch {
+        banCancelSelfStudyUseCase(
+            role = role,
+            userId = userId
+        ).onSuccess {
+            _banCancelSelfStudyState.value = Event.Success()
+        }.onFailure {
+            it.exceptionHandling(
+                notFoundAction = { _banCancelSelfStudyState.value = Event.NotFound }
+            )
+        }
+    }
+
+    fun selfStudy(role: String) = viewModelScope.launch {
+        selfStudyUseCase(role)
+            .onSuccess {
+                val response = it.string()
+                val jsonObject = JSONObject(response)
+                val code = jsonObject.getInt("code")
+
+                if (code == 202) _selfStudyState.value = Event.Accepted
+                else _selfStudyState.value = Event.Success()
+            }.onFailure {
+                it.exceptionHandling(
+                    conflictAction = { _selfStudyState.value = Event.Conflict }
+                )
+            }
+    }
+
+    fun cancelSelfStudy(role: String) = viewModelScope.launch {
+        cancelSelfStudyUseCase(role)
+            .onSuccess {
+                val response = it.string()
+                val jsonObject = JSONObject(response)
+                val code = jsonObject.getInt("code")
+
+                if (code == 202) _cancelSelfStudyState.value = Event.Accepted
+                else _cancelSelfStudyState.value = Event.Success()
+            }.onFailure {
+                it.exceptionHandling(
+                    conflictAction = { _cancelSelfStudyState.value = Event.Conflict }
+                )
+            }
+    }
+
+    fun changeSelfStudyLimit(
+        role: String,
+        limit: Int
+    ) = viewModelScope.launch {
+        changeSelfStudyLimitUseCase(
+            role = role,
+            limit = limit
+        ).onSuccess {
+            _changeSelfStudyLimitState.value = Event.Success()
+        }.onFailure {
+            it.exceptionHandling(
+                unauthorizedAction = { _changeSelfStudyLimitState.value = Event.Unauthorized },
+                forbiddenAction = { _changeSelfStudyLimitState.value = Event.ForBidden }
+            )
+        }
+    }
+
+    fun checkSelfStudy(
+        role: String,
+        memberId: Long,
+        selfStudyCheck: Boolean
+    ) = viewModelScope.launch {
+        checkSelfStudyUseCase(
+            role = role,
+            memberId = memberId,
+            selfStudyCheck = selfStudyCheck
+        ).onSuccess {
+            _checkSelfStudyState.value = Event.Success()
+        }.onFailure {
+            it.exceptionHandling(
+                unauthorizedAction = { _checkSelfStudyState.value = Event.Unauthorized },
+                forbiddenAction = { _checkSelfStudyState.value = Event.ForBidden }
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/msg/presentation/viewmodel/SelfStudyViewModel.kt
+++ b/presentation/src/main/java/com/msg/presentation/viewmodel/SelfStudyViewModel.kt
@@ -139,11 +139,13 @@ class SelfStudyViewModel @Inject constructor(
         selfStudyUseCase(role)
             .onSuccess {
                 val response = it.string()
-                val jsonObject = JSONObject(response)
-                val code = jsonObject.getInt("code")
 
-                if (code == 202) _selfStudyState.value = Event.Accepted
-                else _selfStudyState.value = Event.Success()
+                if (response.isNotEmpty()) {
+                    val jsonObject = JSONObject(response)
+                    val code = jsonObject.getInt("code")
+
+                    if (code == 202) _selfStudyState.value = Event.Accepted
+                } else _selfStudyState.value = Event.Success()
             }.onFailure {
                 it.exceptionHandling(
                     conflictAction = { _selfStudyState.value = Event.Conflict }
@@ -155,11 +157,13 @@ class SelfStudyViewModel @Inject constructor(
         cancelSelfStudyUseCase(role)
             .onSuccess {
                 val response = it.string()
-                val jsonObject = JSONObject(response)
-                val code = jsonObject.getInt("code")
 
-                if (code == 202) _cancelSelfStudyState.value = Event.Accepted
-                else _cancelSelfStudyState.value = Event.Success()
+                if (response.isNotEmpty()) {
+                    val jsonObject = JSONObject(response)
+                    val code = jsonObject.getInt("code")
+
+                    if (code == 202) _cancelSelfStudyState.value = Event.Accepted
+                } else _cancelSelfStudyState.value = Event.Success()
             }.onFailure {
                 it.exceptionHandling(
                     conflictAction = { _cancelSelfStudyState.value = Event.Conflict }

--- a/presentation/src/main/java/com/msg/presentation/viewmodel/util/Event.kt
+++ b/presentation/src/main/java/com/msg/presentation/viewmodel/util/Event.kt
@@ -3,6 +3,7 @@ package com.msg.presentation.viewmodel.util
 sealed class Event<out T>(val data: T? = null) {
     object Loading : Event<Nothing>()
     class Success<T>(data: T? = null) : Event<T>(data = data)
+    object Accepted : Event<Nothing>()
     object BadRequest : Event<Nothing>()
     object Unauthorized : Event<Nothing>()
     object ForBidden : Event<Nothing>()


### PR DESCRIPTION
## 📌 개요
- self study view model logic

## ✨ 구현 내용
- domain에 okhttp 추가
- api service, data source, repository에 responseBody return type 추가(자습신청, 신청 취소에만)
- self study view model 생성

## 📸 구현 화면 (선택)
<!-- 스크린샷이 필요하다면 첨부해주세요 -->

## 📸 구현 영상 (선택)
<!-- 영상이 필요하다면 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
