### PR TITLE
🔀 :: (#86) write youtube music domain logic

### DIFF
--- a/data/src/main/java/com/msg/data/remote/dto/music/response/YoutubeResponse.kt
+++ b/data/src/main/java/com/msg/data/remote/dto/music/response/YoutubeResponse.kt
@@ -1,8 +1,14 @@
 package com.msg.data.remote.dto.music.response
 
 import com.google.gson.annotations.SerializedName
+import com.msg.domain.model.music.response.YoutubeResponseModel
 
 data class YoutubeResponse(
     val title: String,
     @SerializedName("thumbnail_url") val thumbnailUrl: String
+)
+
+fun YoutubeResponse.asYoutubeResponseModel() = YoutubeResponseModel(
+    title = title,
+    thumbnailUrl = thumbnailUrl
 )

--- a/data/src/main/java/com/msg/data/repository/MusicRepositoryImpl.kt
+++ b/data/src/main/java/com/msg/data/repository/MusicRepositoryImpl.kt
@@ -3,8 +3,10 @@ package com.msg.data.repository
 import com.msg.data.remote.datasource.music.MusicDataSource
 import com.msg.data.remote.dto.music.request.asMusicRequest
 import com.msg.data.remote.dto.music.response.asMusicResponseModel
+import com.msg.data.remote.dto.music.response.asYoutubeResponseModel
 import com.msg.domain.model.music.request.MusicRequestModel
 import com.msg.domain.model.music.response.MusicResponseModel
+import com.msg.domain.model.music.response.YoutubeResponseModel
 import com.msg.domain.repository.MusicRepository
 import javax.inject.Inject
 
@@ -19,4 +21,7 @@ class MusicRepositoryImpl @Inject constructor(
 
     override suspend fun deleteMusic(role: String, musicId: Long) =
         musicDataSource.deleteMusic(role, musicId)
+
+    override suspend fun getYoutubeMusic(youtubeUrl: String): YoutubeResponseModel =
+        musicDataSource.getYoutubeMusic(youtubeUrl).asYoutubeResponseModel()
 }

--- a/domain/src/main/java/com/msg/domain/model/music/response/YoutubeResponseModel.kt
+++ b/domain/src/main/java/com/msg/domain/model/music/response/YoutubeResponseModel.kt
@@ -1,0 +1,6 @@
+package com.msg.domain.model.music.response
+
+data class YoutubeResponseModel(
+    val title: String,
+    val thumbnailUrl: String
+)

--- a/domain/src/main/java/com/msg/domain/repository/MusicRepository.kt
+++ b/domain/src/main/java/com/msg/domain/repository/MusicRepository.kt
@@ -2,6 +2,7 @@ package com.msg.domain.repository
 
 import com.msg.domain.model.music.request.MusicRequestModel
 import com.msg.domain.model.music.response.MusicResponseModel
+import com.msg.domain.model.music.response.YoutubeResponseModel
 
 interface MusicRepository {
     suspend fun getMusics(role: String, date: String): List<MusicResponseModel>
@@ -9,4 +10,6 @@ interface MusicRepository {
     suspend fun requestMusic(role: String, body: MusicRequestModel)
 
     suspend fun deleteMusic(role: String, musicId: Long)
+
+    suspend fun getYoutubeMusic(youtubeUrl: String): YoutubeResponseModel
 }

--- a/domain/src/main/java/com/msg/domain/usecase/music/GetYoutubeMusicUseCase.kt
+++ b/domain/src/main/java/com/msg/domain/usecase/music/GetYoutubeMusicUseCase.kt
@@ -1,0 +1,10 @@
+package com.msg.domain.usecase.music
+
+import com.msg.domain.repository.MusicRepository
+import javax.inject.Inject
+
+class GetYoutubeMusicUseCase @Inject constructor(
+    private val repository: MusicRepository
+) {
+    suspend operator fun invoke(youtubeUrl: String) = kotlin.runCatching { repository.getYoutubeMusic(youtubeUrl) }
+}


### PR DESCRIPTION
## 📌 개요
- 유튜브 음악 조회 domain 로직 작성

## ✨ 구현 내용
- YoutubeResponseModel 및 mapper 작성
- MusicRepository에 `getYoutubeMusic()` 구현 및 usecase 구현