### PR TITLE
🔀 :: (#89) write youtube music viewmodel logic

### DIFF
--- a/domain/src/main/java/com/msg/domain/model/music/response/MusicModel.kt
+++ b/domain/src/main/java/com/msg/domain/model/music/response/MusicModel.kt
@@ -1,0 +1,12 @@
+package com.msg.domain.model.music.response
+
+data class MusicModel(
+    val id: Long,
+    val url: String,
+    val username: String,
+    val email: String,
+    val createdTime: String,
+    val stuNum: String,
+    val title: String,
+    val thumbnailUrl: String
+)

--- a/domain/src/main/java/com/msg/domain/usecase/music/GetYoutubeMusicUseCase.kt
+++ b/domain/src/main/java/com/msg/domain/usecase/music/GetYoutubeMusicUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class GetYoutubeMusicUseCase @Inject constructor(
     private val repository: MusicRepository
 ) {
-    suspend operator fun invoke(youtubeUrl: String) = kotlin.runCatching { repository.getYoutubeMusic(youtubeUrl) }
+    suspend operator fun invoke(youtubeUrl: String) = repository.getYoutubeMusic(youtubeUrl)
 }

--- a/domain/src/main/java/com/msg/domain/usecase/music/GetYoutubeMusicUseCase.kt
+++ b/domain/src/main/java/com/msg/domain/usecase/music/GetYoutubeMusicUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class GetYoutubeMusicUseCase @Inject constructor(
     private val repository: MusicRepository
 ) {
-    suspend operator fun invoke(youtubeUrl: String) = repository.getYoutubeMusic(youtubeUrl)
+    suspend operator fun invoke(youtubeUrl: String) = kotlin.runCatching { repository.getYoutubeMusic(youtubeUrl) }
 }

--- a/presentation/src/main/java/com/msg/presentation/view/music/MusicScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/music/MusicScreen.kt
@@ -37,7 +37,7 @@ import com.dotori.dotori_components.components.dialog.DotoriDialog
 import com.dotori.dotori_components.components.music.DotoriMusicListItem
 import com.dotori.dotori_components.theme.DotoriTheme
 import com.msg.domain.model.music.request.MusicRequestModel
-import com.msg.domain.model.music.response.MusicResponseModel
+import com.msg.domain.model.music.response.MusicModel
 import com.msg.presentation.R
 import com.msg.presentation.viewmodel.MusicViewModel
 import com.msg.presentation.viewmodel.util.Event
@@ -133,7 +133,7 @@ fun MusicScreen(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MusicListContent(
-    musicList: List<MusicResponseModel>,
+    musicList: List<MusicModel>,
     onSwitchClick: (Boolean) -> Unit,
     onMusicClick: () -> Unit,
     onCalendarClick: () -> Unit,

--- a/presentation/src/main/java/com/msg/presentation/viewmodel/MusicViewModel.kt
+++ b/presentation/src/main/java/com/msg/presentation/viewmodel/MusicViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.domain.model.music.request.MusicRequestModel
 import com.msg.domain.model.music.response.MusicModel
+import com.msg.domain.model.music.response.YoutubeResponseModel
 import com.msg.domain.usecase.music.DeleteMusicUseCase
 import com.msg.domain.usecase.music.GetMusicsUseCase
 import com.msg.domain.usecase.music.GetYoutubeMusicUseCase
@@ -37,7 +38,9 @@ class MusicViewModel @Inject constructor(
             .onSuccess { result ->
                 _musicUiState.value = Event.Success(
                     result.map {
-                        val youtubeMusic = getYoutubeMusicUseCase(it.url)
+                        val youtubeMusic = getYoutubeMusicUseCase(it.url).getOrDefault(
+                            YoutubeResponseModel(title = "", thumbnailUrl = "")
+                        )
                         MusicModel(
                             id = it.id,
                             url = it.url,

--- a/presentation/src/main/java/com/msg/presentation/viewmodel/MusicViewModel.kt
+++ b/presentation/src/main/java/com/msg/presentation/viewmodel/MusicViewModel.kt
@@ -3,9 +3,10 @@ package com.msg.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.msg.domain.model.music.request.MusicRequestModel
-import com.msg.domain.model.music.response.MusicResponseModel
+import com.msg.domain.model.music.response.MusicModel
 import com.msg.domain.usecase.music.DeleteMusicUseCase
 import com.msg.domain.usecase.music.GetMusicsUseCase
+import com.msg.domain.usecase.music.GetYoutubeMusicUseCase
 import com.msg.domain.usecase.music.RequestMusicUseCase
 import com.msg.presentation.exception.exceptionHandling
 import com.msg.presentation.viewmodel.util.Event
@@ -19,9 +20,10 @@ import javax.inject.Inject
 class MusicViewModel @Inject constructor(
     private val getMusicsUseCase: GetMusicsUseCase,
     private val requestMusicUseCase: RequestMusicUseCase,
-    private val deleteMusicUseCase: DeleteMusicUseCase
+    private val deleteMusicUseCase: DeleteMusicUseCase,
+    private val getYoutubeMusicUseCase: GetYoutubeMusicUseCase
 ) : ViewModel() {
-    private val _musicUiState = MutableStateFlow<Event<List<MusicResponseModel>>>(Event.Loading)
+    private val _musicUiState = MutableStateFlow<Event<List<MusicModel>>>(Event.Loading)
     val musicUiState = _musicUiState.asStateFlow()
 
     private val _requestUiState = MutableStateFlow<Event<Nothing>>(Event.Loading)
@@ -32,8 +34,22 @@ class MusicViewModel @Inject constructor(
 
     fun getMusics(role: String, date: String) = viewModelScope.launch {
         getMusicsUseCase(role, date)
-            .onSuccess {
-                _musicUiState.value = Event.Success(it)
+            .onSuccess { result ->
+                _musicUiState.value = Event.Success(
+                    result.map {
+                        val youtubeMusic = getYoutubeMusicUseCase(it.url)
+                        MusicModel(
+                            id = it.id,
+                            url = it.url,
+                            username = it.username,
+                            email = it.email,
+                            createdTime = it.createdTime,
+                            stuNum = it.stuNum,
+                            title = youtubeMusic.title,
+                            thumbnailUrl = youtubeMusic.thumbnailUrl
+                        )
+                    }
+                )
             }.onFailure {
 
             }


### PR DESCRIPTION
## 📌 개요
- 유튜브 음악 조회 viewmodel 로직 작성

## ✨ 구현 내용
- MusicResponseModel와 YoutubeResponseModel 데이터를 모두 갖는 MusicModel 생성
- `getMusicsUseCase()`에서 받아온 url을 통해 title, thumnailUrl을 얻어와서 map 해주도록 구현