### PR TITLE
🔀 :: (#118) connect notice logic to screen

### DIFF
--- a/presentation/src/main/java/com/msg/presentation/view/notice/NoticeDetailScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/NoticeDetailScreen.kt
@@ -16,9 +16,13 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.dotori.dotori_components.theme.DotoriTheme
 import com.dotori.dotori_components.theme.White
 import com.msg.presentation.R
@@ -26,12 +30,23 @@ import com.msg.presentation.view.music.component.DotoriTopBar
 import com.msg.presentation.view.notice.component.NoticeDetailHeader
 import com.msg.presentation.view.notice.component.NoticeDetailTitle
 import com.msg.presentation.view.util.updateDotoriTheme
+import com.msg.presentation.viewmodel.notice.NoticeDetailViewModel
 import com.skydoves.landscapist.glide.GlideImage
-import java.time.LocalDateTime
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun NoticeDetailScreen() {
+fun NoticeDetailScreen(noticeDetailViewModel: NoticeDetailViewModel = hiltViewModel()) {
+    val roleUiState by noticeDetailViewModel.roleUiState.collectAsState()
+    val noticeUiState by noticeDetailViewModel.noticeUiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        noticeDetailViewModel.getRole()
+        noticeDetailViewModel.getNoticeDetail(
+            role = roleUiState.data!!,
+            noticeId = 1 /* TODO: NavArg로 받아오기 */
+        )
+    }
+
     CompositionLocalProvider(
         LocalOverscrollConfiguration provides null
     ) {
@@ -57,13 +72,13 @@ fun NoticeDetailScreen() {
                     onDeleteClick = { /* TODO: 디자인 생긴 후 처리 */ }
                 )
             }
-            val images = listOf("", "", "")
+            val notice = noticeUiState.data!!
             item {
                 NoticeDetailTitle(
                     modifier = Modifier.padding(horizontal = 20.dp),
-                    title = "[기숙사 자습실 관련 공지]",
-                    createdDate = LocalDateTime.now(),
-                    role = "ROLE_DEVELOPER"
+                    title = notice.title,
+                    createdDate = notice.createdDate,
+                    role = notice.role
                 )
                 Spacer(modifier = Modifier.height(24.dp))
                 Column(
@@ -80,15 +95,11 @@ fun NoticeDetailScreen() {
                         )
                 ) {
                     Text(
-                        text = "기숙사 자습실 관련하여 공지드립니다.\n" +
-                                "[ 기숙사 자습실 관련 공지 ]\n" +
-                                "\n" +
-                                "현재 기숙사에서 화요일까지 정보처리산업기사시험으로인해 금일 자습실 운영에 제한이 생겨 자습인원을 신청한 순서대로 40번째까지만 자습실을 이용하실수있는점 양해바랍니다.\n" +
-                                "궁금한 점 있으시면 이시완#7244으로 문의주시기바랍니다.",
+                        text = notice.content,
                         style = DotoriTheme.typography.body,
                         color = DotoriTheme.colors.neutral10
                     )
-                    images.forEach {
+                    notice.noticeImages.forEach {
                         Spacer(modifier = Modifier.height(16.dp))
                         GlideImage(
                             modifier = Modifier.fillMaxWidth(),

--- a/presentation/src/main/java/com/msg/presentation/view/notice/NoticeDetailScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/NoticeDetailScreen.kt
@@ -19,16 +19,21 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.dotori.dotori_components.components.dialog.DotoriDialog
 import com.dotori.dotori_components.theme.DotoriTheme
 import com.dotori.dotori_components.theme.White
 import com.msg.presentation.R
 import com.msg.presentation.view.music.component.DotoriTopBar
 import com.msg.presentation.view.notice.component.NoticeDetailHeader
 import com.msg.presentation.view.notice.component.NoticeDetailTitle
+import com.msg.presentation.view.notice.component.NoticeDialogContent
 import com.msg.presentation.view.util.updateDotoriTheme
 import com.msg.presentation.viewmodel.notice.NoticeDetailViewModel
 import com.skydoves.landscapist.glide.GlideImage
@@ -36,15 +41,34 @@ import com.skydoves.landscapist.glide.GlideImage
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun NoticeDetailScreen(noticeDetailViewModel: NoticeDetailViewModel = hiltViewModel()) {
+    var showDialog by remember { mutableStateOf(false) }
+
     val roleUiState by noticeDetailViewModel.roleUiState.collectAsState()
     val noticeUiState by noticeDetailViewModel.noticeUiState.collectAsState()
+    val noticeId = 1L /* TODO: NavArg로 받아오기 */
 
     LaunchedEffect(Unit) {
         noticeDetailViewModel.getRole()
         noticeDetailViewModel.getNoticeDetail(
             role = roleUiState.data!!,
-            noticeId = 1 /* TODO: NavArg로 받아오기 */
+            noticeId = noticeId
         )
+    }
+
+    if (showDialog) {
+        DotoriDialog(onDismiss = { showDialog = false }) {
+            NoticeDialogContent(
+                title = "공지사항 삭제",
+                content = "정말로 해당 공지사항을 삭제하겠습니까?",
+                onDismiss = { showDialog = false },
+                onConfirm = {
+                    noticeDetailViewModel.deleteNoticeById(
+                        role = roleUiState.data!!,
+                        noticeId = noticeId
+                    )
+                }
+            )
+        }
     }
 
     CompositionLocalProvider(
@@ -69,7 +93,7 @@ fun NoticeDetailScreen(noticeDetailViewModel: NoticeDetailViewModel = hiltViewMo
                 NoticeDetailHeader(
                     onBackClick = { /* TODO: 뒤로가기 이벤트 처리 */ },
                     onEditClick = { /* TODO: EditScreen 이동 처리 */ },
-                    onDeleteClick = { /* TODO: 디자인 생긴 후 처리 */ }
+                    onDeleteClick = { showDialog = true }
                 )
             }
             val notice = noticeUiState.data!!

--- a/presentation/src/main/java/com/msg/presentation/view/notice/NoticeEditScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/NoticeEditScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,24 +30,42 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.dotori.dotori_components.components.dialog.DotoriDialog
 import com.dotori.dotori_components.components.text_field.DotoriTextField
 import com.dotori.dotori_components.theme.DotoriTheme
 import com.dotori.dotori_components.theme.White
 import com.dotori.dotori_components.theme.XMarkIcon
+import com.msg.domain.model.notice.request.NoticeRequestModel
 import com.msg.presentation.view.music.component.DotoriTopBar
 import com.msg.presentation.view.notice.component.NoticeDialogContent
 import com.msg.presentation.view.notice.component.NoticeEditHeader
 import com.msg.presentation.view.notice.component.NoticeEditImage
 import com.msg.presentation.view.util.updateDotoriTheme
+import com.msg.presentation.viewmodel.notice.NoticeEditViewModel
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun NoticeEditScreen() {
-    var title by remember { mutableStateOf("") }
-    var content by remember { mutableStateOf("") }
+fun NoticeEditScreen(noticeEditViewModel: NoticeEditViewModel = hiltViewModel()) {
+    val noticeId: Long? = 1 /* TODO: NavArg에 선택적으로 받도록 설정 */
+    val roleUiState by noticeEditViewModel.roleUiState.collectAsState()
+    val noticeUiState by noticeEditViewModel.noticeUiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        noticeEditViewModel.getRole()
+
+        if (noticeId != null) {
+            noticeEditViewModel.getNoticeDetail(
+                role = roleUiState.data!!,
+                noticeId = noticeId
+            )
+        }
+    }
+
+    var title by remember { mutableStateOf(noticeUiState.data?.title ?: "") }
+    var content by remember { mutableStateOf(noticeUiState.data?.content ?: "") }
     var showDialog by remember { mutableStateOf(false) }
 
     if (showDialog) {
@@ -78,10 +98,29 @@ fun NoticeEditScreen() {
                     color = DotoriTheme.colors.neutral40
                 )
             }
+            val role = roleUiState.data!!
             stickyHeader {
                 NoticeEditHeader(
                     onBackClick = { showDialog = true },
-                    onSaveClick = { /* TODO: 공지 저장 이벤트 처리 */ }
+                    onSaveClick = {
+                        val noticeRequestModel = NoticeRequestModel(
+                            title = title,
+                            content = content
+                        )
+                        if (noticeId != null) {
+                            noticeEditViewModel.modifyNotice(
+                                role = role,
+                                noticeId = noticeId,
+                                body = noticeRequestModel
+                            )
+                        } else {
+                            noticeEditViewModel.writeNotice(
+                                role = role,
+                                files = emptyList(),
+                                noticeRequestModel = noticeRequestModel
+                            )
+                        }
+                    }
                 )
             }
             val createdDate = LocalDateTime.now()
@@ -92,12 +131,19 @@ fun NoticeEditScreen() {
                         .fillMaxWidth()
                         .padding(horizontal = 20.dp)
                 ) {
+                    val author = when (role) {
+                        "ROLE_DEVELOPER" -> "도토리"
+                        "ROLE_COUNCILLOR" -> "기숙사자치위원회"
+                        "ROLE_ADMIN" -> "사감선생님"
+                        else -> "학생"
+                    }
+
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text(
-                            text = "작성자: 도토리",
+                            text = "작성자: $author",
                             style = DotoriTheme.typography.subTitle1,
                             color = DotoriTheme.colors.neutral10
                         )
@@ -136,11 +182,10 @@ fun NoticeEditScreen() {
                     Spacer(modifier = Modifier.height(32.dp))
                 }
             }
-            val images = listOf("", "", "")
             item {
                 NoticeEditImage(
                     modifier = Modifier.padding(horizontal = 20.dp),
-                    images = images
+                    images = noticeUiState.data?.noticeImages ?: emptyList()
                 )
             }
         }

--- a/presentation/src/main/java/com/msg/presentation/view/notice/NoticeEditScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/NoticeEditScreen.kt
@@ -64,8 +64,9 @@ fun NoticeEditScreen(noticeEditViewModel: NoticeEditViewModel = hiltViewModel())
         }
     }
 
-    var title by remember { mutableStateOf(noticeUiState.data?.title ?: "") }
-    var content by remember { mutableStateOf(noticeUiState.data?.content ?: "") }
+    val notice = noticeUiState.data
+    var title by remember { mutableStateOf(notice?.title ?: "") }
+    var content by remember { mutableStateOf(notice?.content ?: "") }
     var showDialog by remember { mutableStateOf(false) }
 
     if (showDialog) {

--- a/presentation/src/main/java/com/msg/presentation/view/notice/NoticeScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/NoticeScreen.kt
@@ -79,12 +79,14 @@ fun NoticeScreen(noticeViewModel: NoticeViewModel = hiltViewModel()) {
                 )
             }
             stickyHeader {
-                NoticeHeader(
-                    isEditable = isEditable,
-                    onEditClick = { isEditable = !isEditable },
-                    onWriteClick = { /* TODO: NoticeWriteScreen 이동 */ },
-                    onDeleteClick = { showDialog = true }
-                )
+                if (roleUiState.data!! in listOf("ROLE_DEVELOPER", "ROLE_COUNCILLOR", "ROLE_ADMIN")) {
+                    NoticeHeader(
+                        isEditable = isEditable,
+                        onEditClick = { isEditable = !isEditable },
+                        onWriteClick = { /* TODO: NoticeWriteScreen 이동 */ },
+                        onDeleteClick = { showDialog = true }
+                    )
+                }
             }
             item {
                 Divider(

--- a/presentation/src/main/java/com/msg/presentation/view/notice/NoticeScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/NoticeScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.dotori.dotori_components.components.dialog.DotoriDialog
 import com.dotori.dotori_components.components.notice.DotoriNoticeListItem
 import com.dotori.dotori_components.theme.DotoriTheme
@@ -25,16 +28,25 @@ import com.msg.presentation.view.notice.component.MonthDivider
 import com.msg.presentation.view.notice.component.NoticeDialogContent
 import com.msg.presentation.view.notice.component.NoticeHeader
 import com.msg.presentation.view.util.updateDotoriTheme
+import com.msg.presentation.viewmodel.notice.NoticeViewModel
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun NoticeScreen() {
+fun NoticeScreen(noticeViewModel: NoticeViewModel = hiltViewModel()) {
     var isEditable by remember { mutableStateOf(false) }
     var showDialog by remember { mutableStateOf(false) }
 
+    val roleUiState by noticeViewModel.roleUiState.collectAsState()
+    val noticeUiState by noticeViewModel.noticeUiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        noticeViewModel.getRole()
+        noticeViewModel.getAllNotice(roleUiState.data!!)
+    }
+
+    val grouped = noticeUiState.data!!.groupBy { it.createdDate.year to it.createdDate.monthValue }
     val selectedList = remember { mutableListOf<Long>() }
-    val noticeList = listOf(12, 11, 10, 6, 6, 6, 5, 4, 3, 2, 1, 1)
-    val grouped = noticeList.groupBy { it }
 
     if (showDialog) {
         DotoriDialog(onDismiss = { showDialog = false }) {
@@ -42,7 +54,12 @@ fun NoticeScreen() {
                 title = "${selectedList.size}개 항목 삭제",
                 content = "정말로 ${selectedList.size}개의 항목을 삭제 하시겠습니까?",
                 onDismiss = { showDialog = false },
-                onConfirm = { /* TODO */ }
+                onConfirm = {
+                    noticeViewModel.deleteNoticeByIdList(
+                        role = roleUiState.data!!,
+                        body = selectedList
+                    )
+                }
             )
         }
     }
@@ -75,33 +92,39 @@ fun NoticeScreen() {
                     color = DotoriTheme.colors.cardBackground
                 )
             }
-            grouped.forEach { (month, notice) ->
+            grouped.forEach { (yearMonth, notice) ->
                 item {
-                    /* TODO: Notice model이 작성된 후 날짜 로직으로 교체 */
-                    if (month != grouped.keys.first()) {
+                    if (yearMonth != grouped.keys.first()) {
                         MonthDivider(
                             modifier = Modifier.padding(
                                 horizontal = 20.dp,
                                 vertical = 16.dp
                             ),
-                            month = month
+                            month = yearMonth.second
                         )
                     }
                 }
                 items(notice.size) {
+                    val formattedDate = DateTimeFormatter.ofPattern("yyyy.MM.dd").format(notice[it].createdDate)
+
                     DotoriNoticeListItem(
                         modifier = Modifier
                             .padding(horizontal = 20.dp)
                             .padding(top = if (it != 0) 12.dp else 0.dp),
-                        writer = "도토리",
-                        title = "[기숙사 자습실 사용 관련 공지]",
-                        content = "많은 분들이 급식의 화살표를 눌렀을때 날짜만 변경되는 점이 불편하다고 하여 이제는 급식",
-                        date = "2023.${notice[it]}.28",
-                        role = "ROLE_DEVELOPER",
+                        writer = when (notice[it].role) {
+                            "ROLE_DEVELOPER" -> "도토리"
+                            "ROLE_COUNCILLOR" -> "기숙사자치위원회"
+                            "ROLE_ADMIN" -> "사감선생님"
+                            else -> "학생"
+                        },
+                        title = notice[it].title,
+                        content = notice[it].content,
+                        isFocus = notice[it].id in selectedList,
+                        date = formattedDate,
+                        role = notice[it].role,
                     ) {
                         if (isEditable) {
-                            /* TODO: Notice model의 id로 변경 */
-                            selectedList.add(notice[it].toLong())
+                            selectedList.changeNoticeSelected(notice[it].id)
                         } else {
                             /* TODO: NoticeDetailScreen 이동 */
                         }
@@ -110,6 +133,10 @@ fun NoticeScreen() {
             }
         }
     }
+}
+
+private fun MutableList<Long>.changeNoticeSelected(noticeId: Long) {
+    if (noticeId in this) this.remove(noticeId) else this.add(noticeId)
 }
 
 @Preview

--- a/presentation/src/main/java/com/msg/presentation/view/notice/NoticeScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/NoticeScreen.kt
@@ -79,7 +79,12 @@ fun NoticeScreen(noticeViewModel: NoticeViewModel = hiltViewModel()) {
                 )
             }
             stickyHeader {
-                if (roleUiState.data!! in listOf("ROLE_DEVELOPER", "ROLE_COUNCILLOR", "ROLE_ADMIN")) {
+                if (roleUiState.data!! in listOf(
+                        "ROLE_DEVELOPER",
+                        "ROLE_COUNCILLOR",
+                        "ROLE_ADMIN"
+                    )
+                ) {
                     NoticeHeader(
                         isEditable = isEditable,
                         onEditClick = { isEditable = !isEditable },

--- a/presentation/src/main/java/com/msg/presentation/view/notice/component/NoticeEditImage.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/notice/component/NoticeEditImage.kt
@@ -17,13 +17,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.dotori.dotori_components.theme.DotoriTheme
 import com.dotori.dotori_components.theme.ExclamationMarkIcon
+import com.msg.domain.model.notice.response.NoticeImageModel
 import com.msg.presentation.R
 import com.skydoves.landscapist.glide.GlideImage
 
 @Composable
 fun NoticeEditImage(
     modifier: Modifier = Modifier,
-    images: List<String>
+    images: List<NoticeImageModel>
 ) {
     Column(
         modifier = modifier,
@@ -52,7 +53,7 @@ fun NoticeEditImage(
             items(images) {
                 GlideImage(
                     modifier = Modifier.size(192.dp),
-                    imageModel = { it },
+                    imageModel = { it.url },
                     previewPlaceholder = R.drawable.ic_empty_music_icon_light
                 )
             }


### PR DESCRIPTION
## 📌 개요
- 공지사항 로직 연결

## ✨ 구현 내용
- Notice Screen에 맞게 ViewModel 로직 연결
- 공지사항 삭제 Dialog 추가
- NoticeEditImage에서 받는 파라미터 타입을 String -> NoticeImageModel로 변경

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- NoticeEditScreen의 경우 navigation에서 optional argument로 처리하여 작성/수정을 구분하고 있는데 관련 로직 피드백 부탁합니다.