### PR TITLE
🔀 :: (#141) add android cd

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -1,0 +1,93 @@
+name: Dotori-Android CD
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: 11
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+        
+      - name: Create LOCAL_PROPERTIES
+        run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
+        
+      - name: Create service_account.json
+        run: echo '${{ secrets.SERVICE_ACCOUNT_JSON }}' > service_account.json
+
+      - name: Assemble Release Bundle
+        run: ./gradlew bundleRelease
+
+      - name: Sign Release
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+          
+      - name: Upload AAB
+        uses: actions/upload-artifact@v1
+        with:
+          name: app
+          path: app/build/outputs/bundle/release/app-release.aab
+
+      - name: Deploy to production
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: service_account.json
+          packageName: com.msg.dotori
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: beta
+          
+      - name: Dotori Android CD Discord Notification
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ success() }}
+        with:
+          title: ✅ Dotori-Android-CD 성공! ✅
+          webhook: ${{ secrets.DOTORI_DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+          image: ${{ secrets.CD_SUCCESS_IMAGE }}
+          description: 0ㅅ0
+          color: 00FF00
+          url: "https://github.com/sarisia/actions-status-discord"
+          username: Dotori CD 봇
+
+      - name: Dotori Android CD Discord Notification
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ failure() }}
+        with:
+          title: ❗️ Dotori-Android-CD 실패! ❗️
+          webhook: ${{ secrets.DOTORI_DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+          image: ${{ secrets.CD_FAIL_IMAGE }}
+          description: -ㅅ-;
+          color: 00FF00
+          url: "https://github.com/sarisia/actions-status-discord"
+          username: Dotori CD 봇


### PR DESCRIPTION
## 📌 개요
- github action으로 android cd 추가합니다.

## ✨ 구현 내용
- JDK 11 환경을 설정합니다.
- 안드로이드 SDK를 설정합니다.
- gradle 패키지를 캐싱하여 빌드 성능을 향상시킵니다.
- 릴리즈 번들을 생성하고, 릴리즈에 서명합니다.
- AAB 파일을 업로드합니다.
- 프로덕션에 배포합니다.
- 성공이나 실패시에 디스코드에 알림을 전송합니다.