### PR TITLE
🔀 :: (#140) login page publishing

### DIFF
--- a/buildSrc/src/main/java/Dependency.kt
+++ b/buildSrc/src/main/java/Dependency.kt
@@ -42,4 +42,8 @@ object Dependency {
         const val ANDROID_JUNIT = "androidx.test.ext:junit:${Versions.ANDROID_JUNIT}"
         const val ESPRESSO_CORE = "androidx.test.espresso:espresso-core:${Versions.ESPRESSO_CORE}"
     }
+
+    object Msg {
+        const val GAUTH = "com.github.GSM-MSG:GAuth-Signin-Android:v${Versions.GAUTH}"
+    }
 }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -28,4 +28,6 @@ object Versions {
     const val COMPOSE_COMPILER = "1.3.2"
     const val NAVIGATION_COMPOSE = "2.6.0"
     const val LANDSCAPIST_COMPOSE = "2.1.2"
+
+    const val GAUTH = "1.1.2"
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
 
     implementation(Dependency.Google.MATERIAL)
     implementation(Dependency.Google.HILT)
+    implementation("androidx.wear.compose:compose-material:1.2.1")
     kapt(Dependency.Google.HILT_COMPILER)
 
     implementation(Dependency.Libraries.DUS)
@@ -60,6 +61,8 @@ dependencies {
     implementation(Dependency.Compose.COMPOSE_PREVIEW)
     implementation(Dependency.Compose.NAVIGATION_COMPOSE)
     implementation(Dependency.Compose.LANDSCAPIST_COMPOSE)
+
+    implementation(Dependency.Msg.GAUTH)
 
     testImplementation(Dependency.UnitTest.JUNIT)
     androidTestImplementation(Dependency.AndroidTest.ANDROID_JUNIT)

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
 
     implementation(Dependency.Google.MATERIAL)
     implementation(Dependency.Google.HILT)
-    implementation("androidx.wear.compose:compose-material:1.2.1")
     kapt(Dependency.Google.HILT_COMPILER)
 
     implementation(Dependency.Libraries.DUS)

--- a/presentation/src/main/java/com/msg/presentation/view/login/GAuthLoginScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/login/GAuthLoginScreen.kt
@@ -20,13 +20,13 @@ import com.dotori.dotori_components.theme.ArrowLeft2Icon
 import com.dotori.dotori_components.theme.DotoriTheme
 import com.msg.gauthsignin.component.GAuthButton
 import com.msg.gauthsignin.component.utils.Types
+import com.msg.presentation.R
+import androidx.compose.ui.res.stringResource
 
 @Composable
-fun GAuthLoginScreen(
-    modifier: Modifier = Modifier,
-) {
+fun GAuthLoginScreen() {
     Column(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .background(DotoriTheme.colors.background)
             .padding(bottom = 60.dp)
@@ -34,32 +34,32 @@ fun GAuthLoginScreen(
         Box(modifier = Modifier.padding(top = 16.dp)) {
             ArrowLeft2Icon(
                 contentDescription = "ArrowLeftIcon",
-                modifier = modifier.padding(start = 20.dp)
+                modifier = Modifier.padding(start = 20.dp)
             )
             Text(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 2.dp),
-                text = "로그인",
+                text = stringResource(R.string.login_text),
                 style = DotoriTheme.typography.subTitle2,
                 color = DotoriTheme.colors.neutral10,
                 textAlign = TextAlign.Center
             )
         }
         Row(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 50.dp)
         ) { DrawerViewHeader() }
         Text(
-            modifier = modifier
+            modifier = Modifier
                 .size(width = 208.dp, height = 34.dp)
                 .padding(start = 24.dp),
-            text = "광주소프트웨어마이스터고 기숙사 관리 시스템, DOTORI",
+            text = stringResource(R.string.login_page_dotori_description),
             style = DotoriTheme.typography.body2,
             color = DotoriTheme.colors.neutral20
         )
-        Spacer(modifier = modifier.weight(1f))
+        Spacer(modifier = Modifier.weight(1f))
         GAuthButton(
             style = Types.Style.DEFAULT,
             actionType = Types.ActionType.SIGNIN,

--- a/presentation/src/main/java/com/msg/presentation/view/login/GAuthLoginScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/login/GAuthLoginScreen.kt
@@ -1,0 +1,78 @@
+package com.msg.presentation.view.login
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dotori.dotori_components.components.drawer.content.DrawerViewHeader
+import com.dotori.dotori_components.theme.ArrowLeft2Icon
+import com.dotori.dotori_components.theme.DotoriTheme
+import com.msg.gauthsignin.component.GAuthButton
+import com.msg.gauthsignin.component.utils.Types
+
+@Composable
+fun GAuthLoginScreen(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(DotoriTheme.colors.background)
+    ) {
+        Box(modifier = Modifier.padding(top = 16.dp)) {
+            ArrowLeft2Icon(
+                contentDescription = "ArrowLeftIcon",
+                modifier = modifier.padding(start = 20.dp)
+            )
+            Text(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 2.dp),
+                text = "로그인",
+                style = DotoriTheme.typography.subTitle2,
+                color = DotoriTheme.colors.neutral10,
+                textAlign = TextAlign.Center
+            )
+        }
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(top = 50.dp)
+        ) { DrawerViewHeader() }
+        Text(
+            modifier = modifier
+                .size(width = 208.dp, height = 34.dp)
+                .padding(start = 24.dp),
+            text = "광주소프트웨어마이스터고 기숙사 관리 시스템, DOTORI",
+            style = DotoriTheme.typography.body2,
+            color = DotoriTheme.colors.neutral20
+        )
+        Spacer(modifier = modifier.height(504.dp))
+        GAuthButton(
+            style = Types.Style.DEFAULT,
+            actionType = Types.ActionType.SIGNIN,
+            colors = Types.Colors.COLORED,
+            horizontalPaddingValue = 70.dp,
+        ) {
+
+        }
+    }
+}
+
+@Preview
+@Composable
+fun GAuthLoginScreenPreview() {
+    GAuthLoginScreen()
+}

--- a/presentation/src/main/java/com/msg/presentation/view/login/GAuthLoginScreen.kt
+++ b/presentation/src/main/java/com/msg/presentation/view/login/GAuthLoginScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
@@ -30,6 +29,7 @@ fun GAuthLoginScreen(
         modifier = modifier
             .fillMaxSize()
             .background(DotoriTheme.colors.background)
+            .padding(bottom = 60.dp)
     ) {
         Box(modifier = Modifier.padding(top = 16.dp)) {
             ArrowLeft2Icon(
@@ -59,7 +59,7 @@ fun GAuthLoginScreen(
             style = DotoriTheme.typography.body2,
             color = DotoriTheme.colors.neutral20
         )
-        Spacer(modifier = modifier.height(504.dp))
+        Spacer(modifier = modifier.weight(1f))
         GAuthButton(
             style = Types.Style.DEFAULT,
             actionType = Types.ActionType.SIGNIN,

--- a/presentation/src/main/res/values/string.xml
+++ b/presentation/src/main/res/values/string.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name = "login_page_dotori_description">광주소프트웨어마이스터고 기숙사 관리 시스템, DOTORI</string>
+    <string name = "login_text">로그인</string>
+</resources>


### PR DESCRIPTION
## 📌 개요
GAuth로 바뀐 Login Page 퍼블리싱

## ✨ 구현 내용
GAuth로 바뀐 Login Page 퍼블리싱
GAuth SDK 추가

## 📸 구현 화면 (선택)
<img width="293" alt="스크린샷 2023-11-23 오후 6 00 53" src="https://github.com/Team-Ampersand/Dotori-Android/assets/108732289/20006f50-878b-43aa-aad4-198afb9d1286">

